### PR TITLE
Move SiteFinder logic to PSR-14 event

### DIFF
--- a/Classes/EventListener/DisableLanguageSyncListener.php
+++ b/Classes/EventListener/DisableLanguageSyncListener.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThieleUndKlose\Autotranslate\EventListener;
+
+use TYPO3\CMS\Core\Configuration\Event\AfterTcaCompilationEvent;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use ThieleUndKlose\Autotranslate\Utility\TranslationHelper;
+
+final class DisableLanguageSyncListener
+{
+    public function __invoke(AfterTcaCompilationEvent $event): void
+    {
+        $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+        $sites = $siteFinder->getAllSites();
+
+        foreach ($sites as $site) {
+            foreach (TranslationHelper::additionalTables() as $table) {
+                $settings = TranslationHelper::translationSettingsDefaults(
+                    $site->getConfiguration(),
+                    $table
+                );
+                $textFields = GeneralUtility::trimExplode(
+                    ',',
+                    $settings['autotranslateTextfields'] ?? '',
+                    true
+                );
+                foreach ($textFields as $field) {
+                    if (
+                        $GLOBALS['TCA'][$table]['columns'][$field]['config']['behaviour']['allowLanguageSynchronization'] ?? null === true
+                    ) {
+                        $GLOBALS['TCA'][$table]['columns'][$field]['config']['behaviour']['allowLanguageSynchronization'] = false;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -26,3 +26,9 @@ services:
         identifier: 'add-page-configuration'
         event: TYPO3\CMS\Core\TypoScript\IncludeTree\Event\ModifyLoadedPageTsConfigEvent
         method: 'addPageConfiguration'
+
+  ThieleUndKlose\Autotranslate\EventListener\DisableLanguageSyncListener:
+    tags:
+      - name: event.listener
+        identifier: 'disable-language-sync'
+        event: TYPO3\CMS\Core\Configuration\Event\AfterTcaCompilationEvent

--- a/Configuration/TCA/Overrides/additional_tables.php
+++ b/Configuration/TCA/Overrides/additional_tables.php
@@ -1,9 +1,7 @@
 <?php
 
 use ThieleUndKlose\Autotranslate\Utility\TranslationHelper;
-use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 foreach (TranslationHelper::additionalTables() as $table) {
     $extKey = 'autotranslate';
@@ -58,17 +56,5 @@ foreach (TranslationHelper::additionalTables() as $table) {
         'after:' . $GLOBALS['TCA'][$table]['ctrl']['transOrigPointerField']
     );
 
-
-    // remove allowLanguageSynchronization from the fields you want to translate. Otherwise, translations would be reset. (tt_address)
-    $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
-    $sites = $siteFinder->getAllSites();
-    foreach($sites as $site) {
-        $settings = TranslationHelper::translationSettingsDefaults($site->getConfiguration(), $table);
-        $textFields = GeneralUtility::trimExplode(',', $settings['autotranslateTextfields'] ?? '', true);
-        foreach ($textFields as $field) {
-            if ($GLOBALS['TCA'][$table]['columns'][$field]['config']['behaviour']['allowLanguageSynchronization'] ?? null === true) {
-                $GLOBALS['TCA'][$table]['columns'][$field]['config']['behaviour']['allowLanguageSynchronization'] = false;
-            }
-        }
-    }
+    // behaviour adjustments for text fields are applied in ext_localconf.php
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -37,3 +37,5 @@ $GLOBALS['TYPO3_CONF_VARS']['LOG']['ThieleUndKlose']['Autotranslate']['Utility']
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][Configuration::class] = [
     'className' => ConfigurationXclass::class,
 ];
+
+


### PR DESCRIPTION
## Summary
- stop loading SiteFinder during TCA override
- remove extTablesInclusion-PostProcessing hook
- register a DisableLanguageSyncListener for AfterTcaCompilationEvent

## Testing
- `php -l Configuration/TCA/Overrides/additional_tables.php` *(fails: command not found)*
- `composer --version` *(fails: command not found)*